### PR TITLE
Fix bottom nav navigation links

### DIFF
--- a/board.html
+++ b/board.html
@@ -54,18 +54,18 @@
         <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M20 2H4c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm0 18H4V4h16v16z"/></svg>
         <span>빈카드</span>
       </a>
-      <div class="nav-item" data-tab="flags-tab" data-title="국기">
+      <a href="index.html#flags-tab" class="nav-item" data-title="국기">
         <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M14.4 6L14 4H5v17h2v-7h5.6l.4 2h7V6h-5.6z"/></svg>
         <span>국기</span>
-      </div>
+      </a>
       <a href="gener.html" class="nav-item" data-title="만들기">
         <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/></svg>
         <span>만들기</span>
       </a>
-      <div class="nav-item" data-tab="lettering-tab" data-title="글자">
+      <a href="index.html#lettering-tab" class="nav-item" data-title="글자">
         <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M9.93 13.5h4.14L12 7.98zM20 2H4c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-4.05 16.5l-1.14-3H9.17l-1.12 3H5.96l5.11-13h1.86l5.11 13h-2.09z"/></svg>
         <span>글자</span>
-      </div>
+      </a>
       <a href="board.html" class="nav-item active" data-title="게시판">
         <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M3 13h2v-2H3v2zm0 4h2v-2H3v2zm0-8h2V7H3v2zm4 4h14v-2H7v2zm0 4h14v-2H7v2zm0-8h14V7H7v2z"/></svg>
         <span>게시판</span>

--- a/card-board.html
+++ b/card-board.html
@@ -40,18 +40,18 @@
         <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M20 2H4c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm0 18H4V4h16v16z"/></svg>
         <span>빈카드</span>
       </a>
-      <div class="nav-item" data-tab="flags-tab" data-title="국기">
+      <a href="index.html#flags-tab" class="nav-item" data-title="국기">
         <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M14.4 6L14 4H5v17h2v-7h5.6l.4 2h7V6h-5.6z"/></svg>
         <span>국기</span>
-      </div>
+      </a>
       <a href="gener.html" class="nav-item" data-title="만들기">
         <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/></svg>
         <span>만들기</span>
       </a>
-      <div class="nav-item" data-tab="lettering-tab" data-title="글자">
+      <a href="index.html#lettering-tab" class="nav-item" data-title="글자">
         <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M9.93 13.5h4.14L12 7.98zM20 2H4c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-4.05 16.5l-1.14-3H9.17l-1.12 3H5.96l5.11-13h1.86l5.11 13h-2.09z"/></svg>
         <span>글자</span>
-      </div>
+      </a>
       <a href="board.html" class="nav-item" data-title="게시판">
         <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M3 13h2v-2H3v2zm0 4h2v-2H3v2zm0-8h2V7H3v2zm4 4h14v-2H7v2zm0 4h14v-2H7v2zm0-8h14V7H7v2z"/></svg>
         <span>게시판</span>

--- a/free-board.html
+++ b/free-board.html
@@ -42,18 +42,18 @@
         <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M20 2H4c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm0 18H4V4h16v16z"/></svg>
         <span>빈카드</span>
       </a>
-      <div class="nav-item" data-tab="flags-tab" data-title="국기">
+      <a href="index.html#flags-tab" class="nav-item" data-title="국기">
         <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M14.4 6L14 4H5v17h2v-7h5.6l.4 2h7V6h-5.6z"/></svg>
         <span>국기</span>
-      </div>
+      </a>
       <a href="gener.html" class="nav-item" data-title="만들기">
         <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/></svg>
         <span>만들기</span>
       </a>
-      <div class="nav-item" data-tab="lettering-tab" data-title="글자">
+      <a href="index.html#lettering-tab" class="nav-item" data-title="글자">
         <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M9.93 13.5h4.14L12 7.98zM20 2H4c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-4.05 16.5l-1.14-3H9.17l-1.12 3H5.96l5.11-13h1.86l5.11 13h-2.09z"/></svg>
         <span>글자</span>
-      </div>
+      </a>
       <a href="board.html" class="nav-item" data-title="게시판">
         <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M3 13h2v-2H3v2zm0 4h2v-2H3v2zm0-8h2V7H3v2zm4 4h14v-2H7v2zm0 4h14v-2H7v2zm0-8h14V7H7v2z"/></svg>
         <span>게시판</span>

--- a/write-post.html
+++ b/write-post.html
@@ -175,18 +175,18 @@
         <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M20 2H4c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm0 18H4V4h16v16z"/></svg>
         <span>빈카드</span>
       </a>
-      <div class="nav-item" data-tab="flags-tab" data-title="국기">
+      <a href="index.html#flags-tab" class="nav-item" data-title="국기">
         <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M14.4 6L14 4H5v17h2v-7h5.6l.4 2h7V6h-5.6z"/></svg>
         <span>국기</span>
-      </div>
+      </a>
       <a href="gener.html" class="nav-item" data-title="만들기">
         <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/></svg>
         <span>만들기</span>
       </a>
-      <div class="nav-item" data-tab="lettering-tab" data-title="글자">
+      <a href="index.html#lettering-tab" class="nav-item" data-title="글자">
         <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M9.93 13.5h4.14L12 7.98zM20 2H4c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-4.05 16.5l-1.14-3H9.17l-1.12 3H5.96l5.11-13h1.86l5.11 13h-2.09z"/></svg>
         <span>글자</span>
-      </div>
+      </a>
       <a href="board.html" class="nav-item active" data-title="게시판">
         <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M3 13h2v-2H3v2zm0 4h2v-2H3v2zm0-8h2V7H3v2zm4 4h14v-2H7v2zm0 4h14v-2H7v2zm0-8h14V7H7v2z"/></svg>
         <span>게시판</span>


### PR DESCRIPTION
## Summary
- update bottom navigation elements in board-related pages to link to tabs on the main page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68734b9aaeb8832f85adacd57e941d37